### PR TITLE
Refactor `SharedData` configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ install:
   - travis_retry composer install --prefer-dist --no-interaction
 
 script:
-  - phpunit $PHPUNIT_FLAGS
+  - vendor/bin/phpunit $PHPUNIT_FLAGS

--- a/config/shared-data.php
+++ b/config/shared-data.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @see https://github.com/coderello/laravel-shared-data
+ */
 
 return [
 
@@ -7,7 +10,7 @@ return [
      *
      * By default the namespace is equal to 'sharedData'.
      *
-     * It means that the shared data will be accessible from window.sharedData
+     * It means that the shared data will be accessible from `window.sharedData`
      */
     'js_namespace' => 'sharedData',
 

--- a/tests/SharedDataTest.php
+++ b/tests/SharedDataTest.php
@@ -97,4 +97,20 @@ class SharedDataTest extends AbstractTestCase
 
         $this->assertSame($this->sharedData->render(), (string) $this->sharedData);
     }
+
+    /**
+     * @depends testRender
+     */
+    public function testStandaloneInstance()
+    {
+        $sharedData = (new SharedData())
+            ->setJsNamespace('testData');
+
+        $this->assertSame('testData', $sharedData->getJsNamespace());
+
+        $html = $sharedData->render();
+        $expectedHtml = '<script>window[\'testData\'] = [];</script>';
+
+        $this->assertSame($expectedHtml, $html);
+    }
 }


### PR DESCRIPTION
Instead of storing entire `$config` array as internal property, configuration parameters are better to be split via particular fields. Especially, while there is only one configuration parameter - 'js_namespace'.

This refactoring creates more clean code and allows easy creation of standalone `SharedData` instance if necessary.

**Attention:** this is BC break change!