### PR TITLE
Add support for "illuminate/support" 6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# IDE
+.idea
+
+# composer
 vendor
 composer.lock
-.idea
+
+# phpunit
+/phpunit.xml
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=7.1",
         "ext-json": "*",
-        "illuminate/support": "^5.8 | ^6.0"
+        "illuminate/support": "^5.8|^6.0"
     },
     "require-dev": {
         "orchestra/testbench": "^3.8"

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "require": {
         "php": ">=7.1",
         "ext-json": "*",
-        "illuminate/support": "5.8.*"
+        "illuminate/support": "^5.8 | ^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.0"
+        "orchestra/testbench": "^3.8"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Add support for "illuminate/support" 6.0, allowing usage of this extension with Laravel 6.0