### PR TITLE
[Enh] Refactor Blade directive setup

### DIFF
--- a/config/shared-data.php
+++ b/config/shared-data.php
@@ -33,4 +33,12 @@ return [
         'name' => 'shared',
     ],
 
+    /*
+     * Blade directive name.
+     *
+     * By default the Blade directive named 'shared'.
+     *
+     * It means that the shared data rendering will be available in view files via `@shared`
+     */
+    'blade_directive' => 'shared',
 ];

--- a/tests/SharedDataTest.php
+++ b/tests/SharedDataTest.php
@@ -2,6 +2,7 @@
 
 namespace Coderello\SharedData\Tests;
 
+use Coderello\SharedData\Providers\SharedDataServiceProvider;
 use Coderello\SharedData\SharedData;
 use Illuminate\Contracts\Support\Arrayable;
 use JsonSerializable;
@@ -293,11 +294,26 @@ class SharedDataTest extends AbstractTestCase
         $this->assertSame([], $this->sharedData->get());
     }
 
-    public function testDirective()
+    public function testBladeDirective()
     {
         $this->assertEquals(
             shared()->render(),
             view('shared')->render()
+        );
+    }
+
+    /**
+     * @depends testBladeDirective
+     */
+    public function testBladeDirectiveCustom()
+    {
+        $this->app->make('config')->set('shared-data.blade_directive', 'shared_custom');
+
+        $this->app->register(SharedDataServiceProvider::class);
+
+        $this->assertEquals(
+            shared()->render(),
+            view('shared-custom')->render()
         );
     }
 }

--- a/tests/views/shared-custom.blade.php
+++ b/tests/views/shared-custom.blade.php
@@ -1,0 +1,1 @@
+@shared_custom


### PR DESCRIPTION
Blade directive setup has been refactored:

* use `Container::extend()`, allowing lazy-load Blade compiler instantiation as well as correct functioning, when Blade package is not installed.

* Add 'blade.compiler' to `SharedDataServiceProvider::provides()`, ensuring SharedData as well as its Blade directive will be registered correctly once Blade is requested from Container

* Add the configuration for the Blade directive name, as 'shared' is too common and may conflict with other libraries.